### PR TITLE
7 add `Config::new()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Public `config::new()` API (improved config build functionality).
 - Initial MCA file parsing.
 - Initial MSN file parsing.
+
+## [0.3.0] - 2024-02-24
+
+### Added
+- Public `Config::new()` API (improved config build functionality). - resolved [#7]
+
+### Changed
+- `Config::build()` refactored to `Config::build_from_cli()` to be more explicit.
+- `cli` module refactored to `setup` to group both `build_from_cli()` and `new()` functions.
+
+### Fixed
+- Typo in README.md
 
 ## [0.2.1] - 2024-02-18
 
@@ -37,10 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Codecov set-up.
 - Added issue and PR templates.
 
-[unreleased]: https://github.com/heuristic-pedals/atoc2gtfs/compare/v0.2.1...HEAD
+[unreleased]: https://github.com/heuristic-pedals/atoc2gtfs/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/heuristic-pedals/atoc2gtfs/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/heuristic-pedals/atoc2gtfs/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/heuristic-pedals/atoc2gtfs/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/heuristic-pedals/atoc2gtfs/releases/tag/v0.1.0
 
 [#3]: https://github.com/heuristic-pedals/atoc2gtfs/issues/3
 [#8]: https://github.com/heuristic-pedals/atoc2gtfs/issues/8
+[#7]: https://github.com/heuristic-pedals/atoc2gtfs/issues/7

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An ATOC.CIF GB rail schedule can be converted to GTFS using the following comman
 Where:
 
 - `<PATH TO INPUT ATOC>` is the path to the input ATOC.CIF (.zip file).
-- `<PATH TO OUTPUS GTFS>` is the desired output GTFS path (.zip file).
+- `<PATH TO OUTPUT GTFS>` is the desired output GTFS path (.zip file).
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 #![doc = include_str!("../README.md")]
 
-pub mod cli;
+pub mod setup;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::process;
 fn main() {
     // collect command line arguments
     let args: Vec<String> = env::args().collect();
-    let config: setup::Config = setup::Config::build(&args).unwrap_or_else(|err| {
+    let config: setup::Config = setup::Config::build_from_cli(&args).unwrap_or_else(|err| {
         eprintln!("Error parsing arguments: {}", err);
         process::exit(1);
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
-use atoc2gtfs::cli;
+use atoc2gtfs::setup;
 use std::env;
 use std::process;
 
 fn main() {
     // collect command line arguments
     let args: Vec<String> = env::args().collect();
-    let config: cli::Config = cli::Config::build(&args).unwrap_or_else(|err| {
+    let config: setup::Config = setup::Config::build(&args).unwrap_or_else(|err| {
         eprintln!("Error parsing arguments: {}", err);
         process::exit(1);
     });

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -51,6 +51,29 @@ impl<'a> Config<'a> {
 
         Config::new(&parsed_args[1], &parsed_args[2])
     }
+
+    /// Create an instance of `Config`. Used to collect input and output paths, check the
+    /// input exists and is a file, and that both both the input and outpus are zip file.
+    /// Both `.zip` and `.ZIP` are valid extensions.
+    ///
+    /// # Arguments
+    ///
+    /// * `input_path` - Path to the input ATOC zip file to be converted, as a str.
+    /// * `output_path` - Path to user to save the converted GTFS file, as a str.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use atoc2gtfs::setup::Config;
+    /// let input_path = "./tests/data/dummy_empty.zip";
+    /// let output_path = "dummy_output.zip";
+    /// let config = Config::new(&input_path, &output_path);
+    /// assert!(config.is_ok());
+    /// ```
+    /// 
+    /// # See Also
+    ///
+    /// - [Config::build] - Building `Config` by parsing CLI arguments.
     pub fn new(input_path: &'a str, output_path: &'a str) -> Result<Config<'a>, String> {
         let input_path: &Path = Path::new(input_path);
         let output_path: &Path = Path::new(output_path);

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -27,7 +27,7 @@ impl<'a> Config<'a> {
     /// # Examples
     ///
     /// ```
-    /// use atoc2gtfs::cli::Config;
+    /// use atoc2gtfs::setup::Config;
     /// let dummy_parsed_args = vec![
     ///     "".to_string(),                 // empty dummy binary name (not used)
     ///     "./tests/data/dummy_empty.zip".to_string(),  // dummy sub-string query

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2,7 +2,6 @@
 use crate::utils;
 use std::cmp::Ordering;
 use std::path::Path;
-use std::process::Output;
 
 /// Capture and collect the runtime configuration
 pub struct Config<'a> {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -49,24 +49,7 @@ impl<'a> Config<'a> {
             Ordering::Equal => (),
         }
 
-        let input_path: &Path = Path::new(&parsed_args[1]);
-        let output_path: &Path = Path::new(&parsed_args[2]);
-
-        if !input_path.exists() {
-            return Err(format!("{:?} does not exist.", input_path));
-        }
-        if !input_path.is_file() {
-            return Err(format!("{:?} is not a file.", input_path));
-        }
-
-        let accept_zip_exts: Vec<&str> = vec!["zip", "ZIP"];
-        utils::io::check_extension(input_path, &accept_zip_exts)?;
-        utils::io::check_extension(output_path, &accept_zip_exts)?;
-
-        Ok(Config {
-            input_path,
-            output_path,
-        })
+        Config::new(&parsed_args[1], &parsed_args[2])
     }
     pub fn new(input_path: &'a str, output_path: &'a str) -> Result<Config<'a>, String> {
         let input_path: &Path = Path::new(input_path);

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -102,7 +102,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn config_build_on_pass() {
+    fn config_build_from_cli_on_pass() {
         let dummy_input_path = "./tests/data/dummy_empty.zip";
         let dummy_output_path = "dummy_output.zip";
 
@@ -129,7 +129,7 @@ mod tests {
     }
 
     #[test]
-    fn config_too_many_req_args() {
+    fn config_build_from_cli_too_many_req_args() {
         let numerous_args = vec!["".to_string(); 4];
         let config = Config::build_from_cli(&numerous_args);
         // split out assertions to imporve test debug messages
@@ -142,7 +142,7 @@ mod tests {
     }
 
     #[test]
-    fn config_too_few_req_args() {
+    fn config_build_from_cli_too_few_req_args() {
         let sparse_args = vec!["".to_string(); 2];
         let config = Config::build_from_cli(&sparse_args);
         // split out assertions to imporve test debug messages
@@ -155,13 +155,30 @@ mod tests {
     }
 
     #[test]
-    fn config_input_does_not_exist() {
-        let non_exist_input = vec![
-            "".to_string(),
-            "does_not_exist.zip".to_string(),
-            "dummy_output.zip".to_string(),
-        ];
-        let config = Config::build_from_cli(&non_exist_input);
+    fn config_new_on_pass() {
+        let dummy_input_path = "./tests/data/dummy_empty.zip";
+        let dummy_output_path = "dummy_output.zip";
+
+        let config = Config::new(&dummy_input_path, &dummy_output_path);
+        assert!(config.is_ok());
+        let config = config.unwrap();
+        assert_eq!(
+            config.input_path.to_str().unwrap(),
+            dummy_input_path,
+            "Unexpected `input_path` value {:?}",
+            config.input_path
+        );
+        assert_eq!(
+            config.output_path.to_str().unwrap(),
+            dummy_output_path,
+            "Unexpected `file_path` value {:?}",
+            config.output_path
+        );
+    }
+
+    #[test]
+    fn config_new_input_does_not_exist() {
+        let config = Config::new("does_not_exist.zip", "dummy_output.zip");
         assert!(
             config.is_err(),
             "No error raised when provided non-existent input."
@@ -173,13 +190,8 @@ mod tests {
     }
 
     #[test]
-    fn config_input_not_a_file() {
-        let folder_input = vec![
-            "".to_string(),
-            "./tests/data/".to_string(),
-            "dummy_output.zip".to_string(),
-        ];
-        let config = Config::build_from_cli(&folder_input);
+    fn config_new_input_not_a_file() {
+        let config = Config::new("./tests/data/", "dummy_output.zip");
         assert!(
             config.is_err(),
             "No error raised when provided a folder path as an input."
@@ -191,13 +203,8 @@ mod tests {
     }
 
     #[test]
-    fn config_input_not_a_zip() {
-        let text_input = vec![
-            "".to_string(),
-            "./tests/data/dummy_empty.txt".to_string(),
-            "dummy_output.zip".to_string(),
-        ];
-        let config = Config::build_from_cli(&text_input);
+    fn config_new_input_not_a_zip() {
+        let config = Config::new("./tests/data/dummy_empty.txt", "dummy_output.zip");
         assert!(
             config.is_err(),
             "No error raised when provided a text file as input."
@@ -205,13 +212,8 @@ mod tests {
     }
 
     #[test]
-    fn config_output_not_a_zip() {
-        let test_output = vec![
-            "".to_string(),
-            "./tests/data/dummy_empty.zip".to_string(),
-            "dummy_output.text".to_string(),
-        ];
-        let config = Config::build_from_cli(&test_output);
+    fn config_new_output_not_a_zip() {
+        let config = Config::new(&"./tests/data/dummy_empty.zip", "dummy_output.text");
         assert!(
             config.is_err(),
             "No error raised when provided a text file as output."

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2,6 +2,7 @@
 use crate::utils;
 use std::cmp::Ordering;
 use std::path::Path;
+use std::process::Output;
 
 /// Capture and collect the runtime configuration
 pub struct Config<'a> {
@@ -51,6 +52,26 @@ impl<'a> Config<'a> {
 
         let input_path: &Path = Path::new(&parsed_args[1]);
         let output_path: &Path = Path::new(&parsed_args[2]);
+
+        if !input_path.exists() {
+            return Err(format!("{:?} does not exist.", input_path));
+        }
+        if !input_path.is_file() {
+            return Err(format!("{:?} is not a file.", input_path));
+        }
+
+        let accept_zip_exts: Vec<&str> = vec!["zip", "ZIP"];
+        utils::io::check_extension(input_path, &accept_zip_exts)?;
+        utils::io::check_extension(output_path, &accept_zip_exts)?;
+
+        Ok(Config {
+            input_path,
+            output_path,
+        })
+    }
+    pub fn new(input_path: &'a str, output_path: &'a str) -> Result<Config<'a>, String> {
+        let input_path: &Path = Path::new(input_path);
+        let output_path: &Path = Path::new(output_path);
 
         if !input_path.exists() {
             return Err(format!("{:?} does not exist.", input_path));

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -12,17 +12,15 @@ pub struct Config<'a> {
 }
 
 impl<'a> Config<'a> {
-    /// Builds an instance of `Config` after parsing CLI inputs
+    /// Builds an instance of `Config` after parsing CLI inputs. Used to collect input
+    /// and output paths, check the input exists and is a file, and that both both the
+    /// input and outpus are zip file. Both `.zip` and `.ZIP` are valid extensions.
     ///
     /// # Arguments
     ///
     /// * `parsed_args` - A vector of strings denoting the parsed inputs.
     /// Expecting the format: [BINARY_NAME, ATOC_PATH, OUTPUT_PATH] (this
     /// is the result of calling `std::env::args().collect()`)
-    ///
-    /// > Note: the format of `parsed_args` is currently 'awkward' to use. A
-    /// future feature will be to implement `Config::new()` such that use cases
-    /// that don't require a cli can be catered for.
     ///
     /// # Examples
     ///
@@ -33,10 +31,13 @@ impl<'a> Config<'a> {
     ///     "./tests/data/dummy_empty.zip".to_string(),  // dummy sub-string query
     ///     "dummy_output.zip".to_string(),    // dummy file path
     /// ];
-    /// let config = Config::build(&dummy_parsed_args);
+    /// let config = Config::build_from_cli(&dummy_parsed_args);
     /// assert!(config.is_ok());
     /// ```
-    pub fn build(parsed_args: &[String]) -> Result<Config, String> {
+    /// # See Also
+    ///
+    /// - [Config::new] - Create a `Config` instance by supplying arguments directly.
+    pub fn build_from_cli(parsed_args: &[String]) -> Result<Config, String> {
         const NUM_REQ_ARGS: usize = 2;
         let num_inputted_req_args: usize = parsed_args.len() - 1;
         let req_arg_err_msg: String = format!(
@@ -70,10 +71,10 @@ impl<'a> Config<'a> {
     /// let config = Config::new(&input_path, &output_path);
     /// assert!(config.is_ok());
     /// ```
-    /// 
+    ///
     /// # See Also
     ///
-    /// - [Config::build] - Building `Config` by parsing CLI arguments.
+    /// - [Config::build_from_cli] - Building `Config` by parsing CLI arguments.
     pub fn new(input_path: &'a str, output_path: &'a str) -> Result<Config<'a>, String> {
         let input_path: &Path = Path::new(input_path);
         let output_path: &Path = Path::new(output_path);
@@ -110,7 +111,7 @@ mod tests {
             dummy_input_path.to_string(),
             dummy_output_path.to_string(),
         ];
-        let config = Config::build(&dummy_parsed_args);
+        let config = Config::build_from_cli(&dummy_parsed_args);
         assert!(config.is_ok());
         let config = config.unwrap();
         assert_eq!(
@@ -130,7 +131,7 @@ mod tests {
     #[test]
     fn config_too_many_req_args() {
         let numerous_args = vec!["".to_string(); 4];
-        let config = Config::build(&numerous_args);
+        let config = Config::build_from_cli(&numerous_args);
         // split out assertions to imporve test debug messages
         assert!(config.is_err(), "Too many arguments case was not detected.");
         assert!(
@@ -143,7 +144,7 @@ mod tests {
     #[test]
     fn config_too_few_req_args() {
         let sparse_args = vec!["".to_string(); 2];
-        let config = Config::build(&sparse_args);
+        let config = Config::build_from_cli(&sparse_args);
         // split out assertions to imporve test debug messages
         assert!(config.is_err(), "Too few arguments case was not detected.");
         assert!(
@@ -160,7 +161,7 @@ mod tests {
             "does_not_exist.zip".to_string(),
             "dummy_output.zip".to_string(),
         ];
-        let config = Config::build(&non_exist_input);
+        let config = Config::build_from_cli(&non_exist_input);
         assert!(
             config.is_err(),
             "No error raised when provided non-existent input."
@@ -178,7 +179,7 @@ mod tests {
             "./tests/data/".to_string(),
             "dummy_output.zip".to_string(),
         ];
-        let config = Config::build(&folder_input);
+        let config = Config::build_from_cli(&folder_input);
         assert!(
             config.is_err(),
             "No error raised when provided a folder path as an input."
@@ -196,7 +197,7 @@ mod tests {
             "./tests/data/dummy_empty.txt".to_string(),
             "dummy_output.zip".to_string(),
         ];
-        let config = Config::build(&text_input);
+        let config = Config::build_from_cli(&text_input);
         assert!(
             config.is_err(),
             "No error raised when provided a text file as input."
@@ -210,7 +211,7 @@ mod tests {
             "./tests/data/dummy_empty.zip".to_string(),
             "dummy_output.text".to_string(),
         ];
-        let config = Config::build(&test_output);
+        let config = Config::build_from_cli(&test_output);
         assert!(
             config.is_err(),
             "No error raised when provided a text file as output."


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
Added `Config::new()` as a public facing API. Refactored `Config::build()` to `Config::build_from_cli()` to distinguish them. Closes #7.

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
Add a means of creating a `Config` instance without the inconvenience of replicating a parsed CLI into a vector.

## Type of change
<!--- Please select from the options below --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->
Specific unit test added, and all other refactored. All unit tests are passing locally and during CI.

Test configuration details:
- OS: macOS
- `rustc` version: rustc 1.74.1 (a28077b28 2023-12-04)
- `cargo` version: cargo 1.74.1 (ecb9851af 2023-10-18)

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->
None

## Checklist:

- [X] My code follows the intended structure of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Change log has been updated

## Additional comments
<!--- Add any additional comments here --->
None