### PR TITLE
13 add cli help flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - CLI help details using `-h` or `--help` - closes [#13].
+- CLI version display using `-v` or `--version`.
 
 ## [0.4.0] - 2024-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial MCA file parsing.
 - Initial MSN file parsing.
 
+## [0.5.0] - 2024-03-02
+
+### Added
+- CLI help details using `-h` or `--help` - closes [#13].
+
 ## [0.4.0] - 2024-02-28
 
 ### Added
@@ -62,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Codecov set-up.
 - Added issue and PR templates.
 
-[unreleased]: https://github.com/heuristic-pedals/atoc2gtfs/compare/v0.4.0...HEAD
+[unreleased]: https://github.com/heuristic-pedals/atoc2gtfs/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/heuristic-pedals/atoc2gtfs/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/heuristic-pedals/atoc2gtfs/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/heuristic-pedals/atoc2gtfs/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/heuristic-pedals/atoc2gtfs/compare/v0.2.0...v0.2.1
@@ -73,3 +79,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#8]: https://github.com/heuristic-pedals/atoc2gtfs/issues/8
 [#7]: https://github.com/heuristic-pedals/atoc2gtfs/issues/7
 [#11]: https://github.com/heuristic-pedals/atoc2gtfs/issues/11
+[#13]: https://github.com/heuristic-pedals/atoc2gtfs/issues/13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "atoc2gtfs"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atoc2gtfs"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -25,13 +25,19 @@ Other open source ATOC to GTFS conversion tools exist written in a range of prog
 An ATOC.CIF GB rail schedule can be converted to GTFS using the following command with 2 required arguments:
 
 ```bash
-./target/release/atoc2gtfs <PATH TO INPUT ATOC> <PATH TO OUTPUT GTFS>
+./target/release/atoc2gtfs <ATOC INPUT PATH> <GTFS OUTPUT PATH>
 ```
 
 Where:
 
-- `<PATH TO INPUT ATOC>` is the path to the input ATOC.CIF (.zip file).
-- `<PATH TO OUTPUT GTFS>` is the desired output GTFS path (.zip file).
+- `<ATOC INPUT PATH>` is the path to the input ATOC.CIF (.zip file).
+- `<GTFS OUTPUT PATH>` is the desired output GTFS path (.zip file).
+
+Help at the CLI can also be displayed by calling `atoc2gtfs` with a `-h` or `--help` flag, e.g.:
+
+```bash
+./target/release/atoc2gtfs -h
+```
 
 ## License
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,12 @@ fn main() {
         process::exit(0);
     }
 
+    // handle case where version info is requested `atoc2gtfs -v` or `atoc2gtfs --version`
+    if (args.len() == 2) && (args[1] == "-v" || args[1] == "--version") {
+        println!("{}", cli_version_msg());
+        process::exit(0);
+    }
+
     // parse CLI arguments
     let config: Config = Config::build_from_cli(&args).unwrap_or_else(|err| {
         eprintln!("Error parsing arguments: {:?}", err);
@@ -34,6 +40,14 @@ fn cli_help_msg() -> &'static str {
         "    ATOC_INPUT_PATH:\tpath to the input ATOC file (.zip file)\n",
         "    GTFS_OUTPUT_PATH:\tpath to the output GTFS file (.zip file)\n",
     )
+}
+
+// provide version details - use option_env! to handle case where cargo is not used to build
+// advice take from: https://stackoverflow.com/questions/27840394/how-can-a-rust-program-access-meta
+// data-from-its-cargo-package
+fn cli_version_msg() -> &'static str {
+    const VERSION: Option<&str> = option_env!("CARGO_PKG_VERSION");
+    VERSION.unwrap_or("unknown")
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,14 @@ use std::process;
 fn main() {
     // collect command line arguments
     let args: Vec<String> = env::args().collect();
+
+    // handle case where help is requested `atoc2gtfs -h` or `atoc2gtfs --help`
+    if (args.len() == 2) && (args[1] == "-h" || args[1] == "--help") {
+        println!("{}", cli_help_msg());
+        process::exit(0);
+    }
+
+    // parse CLI arguments
     let config: Config = Config::build_from_cli(&args).unwrap_or_else(|err| {
         eprintln!("Error parsing arguments: {:?}", err);
         process::exit(1);
@@ -14,5 +22,42 @@ fn main() {
     if let Err(e) = run(config) {
         eprintln!("atoc2gtfs error: {:?}", e);
         process::exit(1);
+    }
+}
+
+// provide help/usage information
+fn cli_help_msg() -> &'static str {
+    concat!(
+        "ATOC.cif to GTFS conversion tool.\n\n",
+        "Usage: atoc2gtfs [ARGS]...\n\n",
+        "Arguments:\n",
+        "    ATOC_INPUT_PATH:\tpath to the input ATOC file (.zip file)\n",
+        "    GTFS_OUTPUT_PATH:\tpath to the output GTFS file (.zip file)\n",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cli_help_msg;
+
+    #[test]
+    fn cli_help_msg_on_pass() {
+        let msg = cli_help_msg();
+        assert!(
+            msg.contains("Usage:"),
+            "Help message does not contain usage instructions"
+        );
+        assert!(
+            msg.contains("Arguments:"),
+            "Help message does not contain Arguments section"
+        );
+        assert!(
+            msg.contains("ATOC_INPUT_PATH:"),
+            "Does not contain ATOC_INPUT_PATH info"
+        );
+        assert!(
+            msg.contains("GTFS_OUTPUT_PATH:"),
+            "Does not contain GTFS_OUTPUT_PATH info"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,24 +57,25 @@ fn cli_version_msg() -> &'static str {
 mod tests {
     use crate::cli_help_msg;
 
+    // check core parts of help message
     #[test]
     fn cli_help_msg_on_pass() {
         let msg = cli_help_msg();
-        assert!(
-            msg.contains("Usage:"),
-            "Help message does not contain usage instructions"
-        );
-        assert!(
-            msg.contains("Arguments:"),
-            "Help message does not contain Arguments section"
-        );
-        assert!(
-            msg.contains("ATOC_INPUT_PATH:"),
-            "Does not contain ATOC_INPUT_PATH info"
-        );
-        assert!(
-            msg.contains("GTFS_OUTPUT_PATH:"),
-            "Does not contain GTFS_OUTPUT_PATH info"
-        );
+        let checks: [&str; 7] = [
+            "Usage:",
+            "Options:",
+            "-h:",
+            "-v:",
+            "Arguments:",
+            "ATOC_INPUT_PATH:",
+            "GTFS_OUTPUT_PATH:",
+        ];
+        for check in checks {
+            assert!(
+                msg.contains(check),
+                "Help message did not contain '{}'",
+                check
+            );
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,9 +34,12 @@ fn main() {
 // provide help/usage information
 fn cli_help_msg() -> &'static str {
     concat!(
-        "ATOC.cif to GTFS conversion tool.\n\n",
-        "Usage: atoc2gtfs [ARGS]...\n\n",
-        "Arguments:\n",
+        "`atoc2gtfs`: an ATOC to GTFS conversion tool.\n\n",
+        "Usage: atoc2gtfs [OPTIONS] [ARGS]...\n",
+        "\nOptions:\n",
+        "    -h:\tdisplay this help message (or --help)\n",
+        "    -v:\tdisplay the version number (or --version)\n",
+        "\nArguments:\n",
         "    ATOC_INPUT_PATH:\tpath to the input ATOC file (.zip file)\n",
         "    GTFS_OUTPUT_PATH:\tpath to the output GTFS file (.zip file)\n",
     )

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -45,18 +45,25 @@ impl<'a> Config<'a> {
     /// - [Config::new] - Create a `Config` instance by supplying arguments directly.
     pub fn build_from_cli(parsed_args: &[String]) -> Result<Config, Box<dyn Error>> {
         const NUM_REQ_ARGS: usize = 2;
-        let num_inputted_req_args: usize = parsed_args.len() - 1;
+        // strip out optional arguments
+        let parsed_req_args = parsed_args
+            .iter()
+            .filter(|arg| !arg.starts_with('-'))
+            .collect::<Vec<&String>>();
+        // subtract 1 to account for initial not needed 0th element (binary file location)
+        let num_inputted_req_args: usize = parsed_req_args.len() - 1;
         let req_arg_err_msg: String = format!(
             " required arguments provided. Expected {}, got {}.",
             NUM_REQ_ARGS, num_inputted_req_args
         );
+        // handle too few/many arguments cases
         match num_inputted_req_args.cmp(&NUM_REQ_ARGS) {
             Ordering::Greater => return Err(("Too many".to_string() + &req_arg_err_msg).into()),
             Ordering::Less => return Err(("Too few".to_string() + &req_arg_err_msg).into()),
             Ordering::Equal => (),
         }
 
-        Config::new(&parsed_args[1], &parsed_args[2])
+        Config::new(parsed_req_args[1], parsed_req_args[2])
     }
 
     /// Create an instance of `Config`. Used to collect input and output paths, check the


### PR DESCRIPTION
## Description
<!--- Please include a summary of the change and which issue is fixed. --->
Added `-h`/`--help` flags to display help information at the CLI - Closes #13.
Also added `-v`/`--version` flags to display version details.

## Motivation and Context
<!--- Please provide a short motivation and context for raising this PR --->
As described above.

## Type of change
<!--- Please select from the options below --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for
your test configuration --->
Tested locally and in CI - working as expected. Core parts of help message are also covered by a unit test.

Test configuration details:
- OS: macOS
- `rustc` version: rustc 1.74.1 (a28077b28 2023-12-04)
- `cargo` version: cargo 1.74.1 (ecb9851af 2023-10-18)

## Advice for reviewer
<!--- Please add any helpful advice for the reviewer that may provide
additional context, for example 'changes in file X are for reasons Y and Z'
--->
None

## Checklist:

- [x] My code follows the intended structure of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Change log has been updated

## Additional comments
<!--- Add any additional comments here --->
None
